### PR TITLE
Fixed a bug where setting prefs after searching breaks the search results

### DIFF
--- a/project_5_files/js/main.js
+++ b/project_5_files/js/main.js
@@ -45,11 +45,17 @@ $(window).on('load', function() {
 	$(".loader").fadeOut(); 
     $("#preloder").delay(400).fadeOut("slow");
     userPanel();
-    prefs();
-    var urlParams = new URLSearchParams(location.search);
-    var searchText = urlParams.get("searchText");
-    searchEngine(searchText);
-    loadSlider();
+    //console.log(window.location);
+    var address = window.location.toString();
+    if (address.includes('preferences.html')) {
+        prefs();
+        loadSlider();
+    }
+    if (address.includes('searchResults.html')) {
+        var urlParams = new URLSearchParams(location.search);
+        var searchText = urlParams.get("searchText");
+        searchEngine(searchText);
+    }
 });
 
 function setResults(num, response) {


### PR DESCRIPTION
Searching for something, then setting preferences, then searching again used to always return the default results instead of searching properly. This has been fixed.